### PR TITLE
Build with warnings as errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,13 +6,14 @@ option(CONAN "Use conan package manager" OFF)
 project(ParkingSpaceSharing LANGUAGES CXX VERSION 0.0.1)
 
 if(NOT MSVC)
-    #add_compile_options(-Werror -Wall -Wextra -Wpedantic -Wconversion -Wshadow)
-    add_compile_options(         -Wall -Wextra -Wpedantic -Wconversion -Wshadow)
+    add_compile_options(-Werror -Wall -Wextra -Wpedantic -Wconversion -Wshadow)
 
     if(CMAKE_BUILD_TYPE STREQUAL "Debug")
         add_compile_options (-fsanitize=address,leak,undefined)
         add_link_options    (-fsanitize=address,leak,undefined)
     endif()
+else()
+    add_compile_options(/W4 /WX)
 endif()
 
 if(CONAN)


### PR DESCRIPTION
Enables warnings as errors for compilers.
Also enables /W4 for MSVC.