### PR TITLE
Configuration file support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@
 *.app
 
 build/*
+**/config.toml

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,8 @@ find_package(oatpp         1.3.0 REQUIRED)
 find_package(oatpp-swagger 1.3.0 REQUIRED)
 find_package(oatpp-sqlite  1.3.0 REQUIRED)
 
+find_package(toml11 3.7 REQUIRED)
+
 #find_package(QT NAMES Qt5 COMPONENTS Core Quick REQUIRED)
 #find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Core Quick REQUIRED)
 

--- a/cmake/conan.cmake
+++ b/cmake/conan.cmake
@@ -13,6 +13,7 @@ conan_cmake_configure(
         oatpp/1.3.0
         oatpp-swagger/1.3.0
         oatpp-sqlite/1.3.0
+        toml11/3.7.1
 
     GENERATORS
         cmake_paths

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -4,6 +4,7 @@ target_sources(
     server PRIVATE
 
     src/main.cc
+    src/config.cc
     src/error_handler.cc
     src/service/user_service.cc
     src/service/offer_service.cc
@@ -29,5 +30,6 @@ target_link_libraries(
     PUBLIC oatpp::oatpp
     PUBLIC oatpp::oatpp-swagger
     PUBLIC oatpp::oatpp-sqlite
+    PUBLIC toml11::toml11
 )
 

--- a/server/src/component/app_component.hh
+++ b/server/src/component/app_component.hh
@@ -12,6 +12,7 @@
 #include <oatpp/web/server/HttpConnectionHandler.hpp>
 #include <oatpp/web/server/HttpRouter.hpp>
 
+#include "config.hh"
 #include "error_handler.hh"
 
 #include "component/database_component.hh"
@@ -34,7 +35,8 @@ public:
     }());
 
     OATPP_CREATE_COMPONENT(::std::shared_ptr<::oatpp::network::ServerConnectionProvider>, server_connection_provider)([]{
-        return ::oatpp::network::tcp::server::ConnectionProvider::createShared({"0.0.0.0", 8000, ::oatpp::network::Address::IP_4});
+        auto const& config = ::server::config::get_instance();
+        return ::oatpp::network::tcp::server::ConnectionProvider::createShared({config.bind, config.port, ::oatpp::network::Address::IP_4});
     }());
 
     OATPP_CREATE_COMPONENT(::std::shared_ptr<::oatpp::web::server::HttpRouter>, http_router)([]{

--- a/server/src/component/swagger_component.hh
+++ b/server/src/component/swagger_component.hh
@@ -7,6 +7,8 @@
 #include <oatpp-swagger/Model.hpp>
 #include <oatpp-swagger/Resources.hpp>
 
+#include "config.hh"
+
 namespace server::component
 {
 
@@ -14,12 +16,13 @@ class swagger_component
 {
 public:
     OATPP_CREATE_COMPONENT(::std::shared_ptr<::oatpp::swagger::DocumentInfo>, swagger_document_info)([]{
+        auto const& config = ::server::config::get_instance();
         return
             ::oatpp::swagger::DocumentInfo::Builder{}
                 .setTitle("Parking space sharing")
                 .setDescription("Project created by trainees of Bakcyl Programowania in 2022/2023.")
-                .setVersion("0.0.1")
-                .addServer("http://localhost:8000", "server on localhost")
+                .setVersion("0.0.1") // TODO(Piotr Stefański): set to git commit hash?
+                .addServer(config.info_url, config.info_description)
                 .build();
     }());
 

--- a/server/src/config.cc
+++ b/server/src/config.cc
@@ -1,0 +1,63 @@
+#include "config.hh"
+
+#include <fstream>
+#include <iostream>
+
+namespace server
+{
+
+namespace detail
+{
+
+// This also dumps the default config file to the default location
+// if no config file was found.
+//
+// TODO(Piotr Stefański): Search for config files in directories like
+//                        $XDG_CONFIG_HOME/parkign_space_sharing/config.toml
+//                        instead of just ./config.toml
+::server::config
+get_config()
+{
+    ::server::config config{};
+
+    try {
+        std::cout << "Found config file 'config.toml'\n";
+        config = ::toml::get<::server::config>(::toml::parse("config.toml"));
+    } catch(std::runtime_error&) {
+        // Catch file not found exception.
+        // Unfortunately there is no more specific class to catch.
+
+        std::cout << "Could not find the config file,\n"
+                     "dumping the default values.\n";
+        // This will construct the config with default values.
+        // See config.hh from_toml()
+        config = ::toml::get<::server::config>(::toml::value{});
+    }
+
+    ::toml::value config_toml = config;
+    std::cout << "Current config:\n" << config_toml;
+
+    // Write the config to file even when one was already there.
+    std::ofstream{
+        "./config.toml",
+        ::std::ios_base::in |
+        ::std::ios_base::trunc
+    } << config_toml;
+
+
+    return config;
+};
+
+} // namespace detail
+
+config const&
+config::get_instance()
+{
+    static
+    config const
+    config{ detail::get_config() };
+
+    return config;
+}
+
+} // namespace server

--- a/server/src/config.hh
+++ b/server/src/config.hh
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <toml.hpp>
+
+namespace server
+{
+
+// When changing value types of members
+// also update template argument of from_toml().
+struct config
+{
+    ::std::string bind;
+    ::std::uint16_t port;
+
+    ::std::string info_url;
+    ::std::string info_description;
+
+    static
+    ::server::config const&
+    get_instance();
+};
+
+} // namespace server
+
+namespace toml
+{
+
+template<>
+struct from<::server::config>
+{
+    static
+    ::server::config from_toml(::toml::value const& val)
+    {
+        auto server = ::toml::find_or(val, "server", {});
+        auto server_info = ::toml::find_or(server, "info", {});
+
+        return ::server::config
+        {
+            .bind = ::toml::find_or<::std::string>(server, "bind", "0.0.0.0"),
+            .port = ::toml::find_or<::std::uint16_t>(server, "port", 8000),
+
+            .info_url = ::toml::find_or<::std::string>(server_info, "url", "http://localhost:8000"),
+            .info_description = ::toml::find_or<::std::string>(server_info, "description", "server on localhost"),
+        };
+    }
+};
+
+template<>
+struct into<::server::config>
+{
+    static
+    ::toml::value into_toml(::server::config const& config)
+    {
+        // When writing to file values will be written last to first
+        // thus the reverse order.
+        return ::toml::value(
+                {{"server",{
+                    {"info", {
+                        {"description", config.info_description},
+                        {"url",         config.info_url},
+                    }},
+                    {"port", config.port},
+                    {"bind", config.bind}
+                }}}
+        );
+    }
+};
+
+} // namespace toml

--- a/server/src/main.cc
+++ b/server/src/main.cc
@@ -33,7 +33,11 @@ main()
     OATPP_COMPONENT(::std::shared_ptr<::oatpp::network::ConnectionHandler>, connection_handler);
 
     ::oatpp::network::Server server{server_connection_provider, connection_handler};
-    OATPP_LOGD("Server", "Server running on port %s", server_connection_provider->getProperty("port").toString()->c_str());
+    OATPP_LOGD(
+            "Server",
+            "Server running on %s:%s",
+            server_connection_provider->getProperty("host").toString()->c_str(),
+            server_connection_provider->getProperty("port").toString()->c_str());
 
     server.run();
 


### PR DESCRIPTION
Adds `server::config` struct to hold application's configuration read from `config.toml` file.

Currently the application only looks for the file in the current working directory. If the file does not exist, it will be created with the default values.