### PR TITLE
Look for config file in platform specific paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,4 @@
 *.app
 
 build/*
-**/config.toml
+/app_config

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,8 @@ if(NOT MSVC)
         add_link_options    (-fsanitize=address,leak,undefined)
     endif()
 else()
-    add_compile_options(/W4 /WX)
+    # 4996 - getenv unsafe
+    add_compile_options(/W4 /WX /wd4996)
 endif()
 
 if(CONAN)

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,13 @@ RUN python3 -m ensurepip
 RUN pip3 install --no-cache pip setuptools conan==1.59.0
 
 FROM deps AS server
+
 COPY . /build
 WORKDIR /build
 RUN cmake -S. -Bbuild -G Ninja -DCMAKE_BUILD_TYPE:STRING=Release -DCONAN:BOOL=ON
 RUN cmake --build build
+
+ENV XDG_CONFIG_HOME=/app_config
+RUN mkdir -p $XDG_CONFIG_HOME
 
 CMD ["/build/build/bin/server"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,9 @@ services:
     image: pss/server
     ports:
       - "8000:8000/tcp"
+    # Uncomment if you want to access/modify the config file
+    #volumes:
+    #  - ./app_config:/app_config:rw
     build:
       context: .
       dockerfile: ./Dockerfile

--- a/server/src/config.cc
+++ b/server/src/config.cc
@@ -1,5 +1,7 @@
 #include "config.hh"
 
+#include <cstdlib>
+#include <filesystem>
 #include <fstream>
 #include <iostream>
 
@@ -9,37 +11,76 @@ namespace server
 namespace detail
 {
 
+/**
+   @brief Find directory for storing config files.
+ */
+::std::filesystem::path
+get_config_home()
+{
+    char const* xdg_config_home_dir = ::std::getenv("XDG_CONFIG_HOME");
+    if(xdg_config_home_dir != nullptr) {
+        return xdg_config_home_dir;
+    }
+
+    char const* appdata_dir = ::std::getenv("APPDATA");
+    if(appdata_dir != nullptr) {
+        return appdata_dir;
+    }
+
+    char const* home_dir = ::std::getenv("HOME");
+    if(home_dir != nullptr) {
+        return ::std::filesystem::path{home_dir} / ".config";
+    }
+
+    throw ::std::runtime_error{"XDG_CONFIG_HOME or APPDATA environment variable not present."};
+}
+
+static constexpr
+char const* CONFIG_FILE_DIR = "parking_space_sharing";
+
+static constexpr
+char const* CONFIG_FILE_NAME = "config.toml";
+
+/**
+   @brief Returns platform specific config path, and ensures that it exists.
+ */
+::std::filesystem::path
+get_and_ensure_config_path()
+{
+    auto config_path = get_config_home() / CONFIG_FILE_DIR;
+    // Make sure that the directory exists
+    ::std::filesystem::create_directory(config_path);
+
+    config_path /= CONFIG_FILE_NAME;
+    return config_path;
+}
+
 // This also dumps the default config file to the default location
 // if no config file was found.
-//
-// TODO(Piotr Stefański): Search for config files in directories like
-//                        $XDG_CONFIG_HOME/parkign_space_sharing/config.toml
-//                        instead of just ./config.toml
 ::server::config
 get_config()
 {
     ::server::config config{};
 
-    try {
-        std::cout << "Found config file 'config.toml'\n";
-        config = ::toml::get<::server::config>(::toml::parse("config.toml"));
-    } catch(std::runtime_error&) {
-        // Catch file not found exception.
-        // Unfortunately there is no more specific class to catch.
-
-        std::cout << "Could not find the config file,\n"
-                     "dumping the default values.\n";
+    auto config_path = get_and_ensure_config_path();
+    if(::std::filesystem::exists(config_path)) {
+        ::std::cout << "Using " << config_path << "\n";
+        config = ::toml::get<::server::config>(::toml::parse(config_path));
+    } else {
+        ::std::cout << "Could not find the config file, "
+                       "dumping the default values.\n"
+                       "The new config file will be placed in " << config_path << ".\n";
         // This will construct the config with default values.
         // See config.hh from_toml()
         config = ::toml::get<::server::config>(::toml::value{});
     }
 
     ::toml::value config_toml = config;
-    std::cout << "Current config:\n" << config_toml;
+    ::std::cout << "Current config:\n" << config_toml;
 
     // Write the config to file even when one was already there.
-    std::ofstream{
-        "./config.toml",
+    ::std::ofstream{
+        config_path,
         ::std::ios_base::in |
         ::std::ios_base::trunc
     } << config_toml;


### PR DESCRIPTION
Addresses: #32 

Looks for the following directories in order:
 - `%APPDATA%/parking_space_sharing`
 - `$XDG_CONFIG_HOME/parking_space_sharing`
 - `$HOME/.config/parking_space_sharing`

Throws `std::runtime_error` if none of these environment variables were defined.