### PR TITLE
change back from using milliseconds to seconds

### DIFF
--- a/server/src/Config.hh
+++ b/server/src/Config.hh
@@ -38,7 +38,7 @@ struct Config
 namespace toml {
 
 using server::Config;
-using std::chrono::duration_cast, std::chrono::days, std::chrono::milliseconds;
+using std::chrono::duration_cast, std::chrono::days, std::chrono::seconds;
 
 template<>
 struct [[maybe_unused]] from<Config>
@@ -60,7 +60,7 @@ struct [[maybe_unused]] from<Config>
             .jwt_expire_after = toml::find_or<std::uint64_t>(
               jwt,
               "expire_after",
-              duration_cast<milliseconds>(days{ 30 }).count()), // NOLINT
+              duration_cast<seconds>(days{ 30 }).count()), // NOLINT
             .swagger_res_path = toml::find_or<std::string>(
               swagger,
               "res_path",

--- a/server/src/TokenUtils.cc
+++ b/server/src/TokenUtils.cc
@@ -2,7 +2,7 @@
 
 namespace server {
 
-using std::chrono::system_clock, std::chrono::milliseconds;
+using std::chrono::system_clock, std::chrono::seconds;
 
 TokenUtils::TokenUtils(std::string secret, std::string issuer)
   : secret_(std::move(secret))
@@ -24,7 +24,7 @@ TokenUtils::createToken(std::shared_ptr<TokenPayload> payload)
         .set_issued_at(now)
         .set_not_before(now)
         .set_expires_at(now +
-                        milliseconds{ Config::getInstance().jwt_expire_after })
+                        seconds{ Config::getInstance().jwt_expire_after })
         .set_type("JWS")
         .set_payload_claim("user_id", jwt::claim{ *payload->user_id })
         .set_payload_claim("role", jwt::claim{ payload->user_role })


### PR DESCRIPTION
As timestamp created by `jwt-cpp` is in seconds we don't need to store it in milliseconds