### PR TITLE
Validate e-mail addresses

### DIFF
--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -10,6 +10,7 @@ target_sources(
     src/Config.cc
     src/ErrorHandler.cc
     src/TokenUtils.cc
+    src/EmailValidation.cc
 
     src/database/MainDatabase.cc
 

--- a/server/src/EmailValidation.cc
+++ b/server/src/EmailValidation.cc
@@ -1,0 +1,18 @@
+#include "EmailValidation.hh"
+
+#include <oatpp/web/protocol/http/Http.hpp>
+
+#include <regex>
+
+namespace server {
+
+void
+validateEmailHTTP(oatpp::String const& email)
+{
+    std::regex email_rg{ EMAIL_REGEX };
+    OATPP_ASSERT_HTTP(std::regex_search(*email, email_rg),
+                      oatpp::web::protocol::http::Status::CODE_400,
+                      "Invalid e-mail format")
+}
+
+} // namespace server

--- a/server/src/EmailValidation.hh
+++ b/server/src/EmailValidation.hh
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <oatpp/core/Types.hpp>
+
+namespace server {
+
+// RFC 5322 compliant email regex
+static constexpr char const* EMAIL_REGEX =
+  R"str(([!#-'*+/-9=?A-Z^-~-]+(\.[!#-'*+/-9=?A-Z^-~-]+)*|"([]!#-[^-~ \t]|(\\[\t -~]))+")@([!#-'*+/-9=?A-Z^-~-]+(\.[!#-'*+/-9=?A-Z^-~-]+)*|\[[\t -Z^-~]*]))str";
+
+void
+validateEmailHTTP(oatpp::String const& email);
+
+} // namespace server

--- a/server/src/controller/UserController.hh
+++ b/server/src/controller/UserController.hh
@@ -167,6 +167,8 @@ class UserController : public oatpp::web::server::api::ApiController
 
         info->addResponse<oatpp::Object<dto::UserDto>>(Status::CODE_200,
                                                        "application/json");
+        info->addResponse<oatpp::Object<dto::StatusDto>>(Status::CODE_400,
+                                                         "application/json");
         info->addResponse<oatpp::Object<dto::StatusDto>>(Status::CODE_401,
                                                          "application/json");
         info->addResponse<oatpp::Object<dto::StatusDto>>(Status::CODE_403,

--- a/server/src/service/AuthService.cc
+++ b/server/src/service/AuthService.cc
@@ -1,10 +1,13 @@
 #include "AuthService.hh"
 
+#include "EmailValidation.hh"
+
 namespace server::service {
 
 Object<StatusDto>
 AuthService::signUp(Object<SignUpDto> const& dto)
 {
+    validateEmailHTTP(dto->email);
     {
         auto query_result = database_->getUserByEmail(dto->email);
 

--- a/server/src/service/UserService.cc
+++ b/server/src/service/UserService.cc
@@ -1,5 +1,7 @@
 #include "UserService.hh"
 
+#include "EmailValidation.hh"
+
 namespace server::service {
 
 std::shared_ptr<UserService>
@@ -11,6 +13,8 @@ UserService::createShared()
 Object<UserDto>
 UserService::createOne(Object<UserDto> const& dto)
 {
+    validateEmailHTTP(dto->email);
+
     try {
         this->getOne(dto->id); // Will throw 404 if not found
         OATPP_ASSERT_HTTP(false, Status::CODE_409, "User already exists")
@@ -104,6 +108,8 @@ UserService::search(String const& query,
 Object<UserDto>
 UserService::putOne(Object<UserDto> const& dto)
 {
+    validateEmailHTTP(dto->email);
+
     auto query_result = database_->replaceUser(dto);
 
     OATPP_ASSERT_HTTP(query_result->isSuccess(),
@@ -125,6 +131,10 @@ UserService::putOne(Object<UserDto> const& dto)
 Object<UserDto>
 UserService::patchOne(UInt64 const& id, Object<UserDto> const& dto)
 {
+    if (dto->email) {
+        validateEmailHTTP(dto->email);
+    }
+
     auto existing = this->getOne(id);
 
     existing->id = dto->id ? dto->id : existing->id;


### PR DESCRIPTION
Validate e-mail addresses using RFC 5322 compliant regex. Validation happens on:
 - /signup POST
 - /user PATCH, POST, PUT